### PR TITLE
Made StWelcomeBrowser take the display scale factor into account for the world menu item with the #pharo icon

### DIFF
--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -27,7 +27,7 @@ StWelcomeBrowser class >> menuCommandOn: aBuilder [
 		parent: #PharoHelp;
 		order: 1;
 		action: [ self open ];
-		icon: ((self iconNamed: #pharoIcon) scaledToSize: 16@16);
+		icon: ((self iconNamed: #pharoIcon) scaledToSize: (16@16) scaledByDisplayScaleFactor);
 		help: 'Welcome window for Pharo'
 ]
 


### PR DESCRIPTION
This pull request makes StWelcomeBrowser take the display scale factor into account for the world menu item with the #pharo icon.