### PR TITLE
Make #windowExtent in StWelcomeBrowser take the display scale factor into account

### DIFF
--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -56,7 +56,7 @@ StWelcomeBrowser class >> openForRelease [
 { #category : #accessing }
 StWelcomeBrowser class >> windowExtent [
 
-	^ 700@550
+	^ (700@550) scaledByDisplayScaleFactor
 ]
 
 { #category : #private }


### PR DESCRIPTION
This pull request makes `#windowExtent` in StWelcomeBrowser take the display scale factor into account.