### PR TITLE
Fix microdown dependency conflict

### DIFF
--- a/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
+++ b/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
@@ -32,7 +32,7 @@ BaselineOfWelcomeBrowser >> microdown: spec [
 
 	spec baseline: 'Microdown' with: [
 		spec
-			repository: 'github://pillar-markup/Microdown:integration/src';
+			repository: 'github://pillar-markup/Microdown:Pharo12/src';
 			loads: #('RichText') ]
 ]
 


### PR DESCRIPTION
This repo branch Pharo12 has a conflicting version with Pharo12's microdown.

- Pharo12 (BaselineOfIDE) downloads Microdown/Pharo12
- BeautifulComments downloads Microdown/Pharo12
- NewToolsDocumentBrowser downloads Microdown/Pharo12

However, this repo downloads *Microdown/integration*
Somehow metacello lets this pass during the bootstrap, but this is a problem in my fixed version of metacello that correctly detects conflicts :)