### PR TITLE
Redo #14 -- postload should use spec to get repository url

### DIFF
--- a/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
+++ b/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
@@ -10,7 +10,7 @@ BaselineOfWelcomeBrowser >> baseline: spec [
 	<baseline>
 
 	spec for: #'common' do: [
-		spec postLoadDoIt: #loadThemeImages.
+		spec postLoadDoIt: #loadThemeImages:.
 		
 		self microdown: spec.
 		spec 
@@ -19,11 +19,11 @@ BaselineOfWelcomeBrowser >> baseline: spec [
 ]
 
 { #category : 'postload' }
-BaselineOfWelcomeBrowser >> loadThemeImages [
+BaselineOfWelcomeBrowser >> loadThemeImages: spec [
 	| themeClass location |
 
 	themeClass := self class environment classNamed: #StWelcomeTheme.
-	location := 	self repositoryLocation.
+	location := 	self repositoryLocation: spec.
 	themeClass loadAllImagesFrom: location / 'resources' / 'themes'
 ]
 
@@ -37,31 +37,21 @@ BaselineOfWelcomeBrowser >> microdown: spec [
 ]
 
 { #category : 'private' }
-BaselineOfWelcomeBrowser >> packageRepository [
-	" Tries to determine a repository from which the baseline is being loaded. Useful for 
-	refering other baselines in the same repository. "
-	
-	^ (self class package mcWorkingCopy repositoryGroup repositories 
-		reject: [:each | each = MCCacheRepository uniqueInstance]) 
-		ifNotEmpty: [ :repositories | 
-			repositories 
-				detect: [ :each | each description beginsWith: 'tonel://' ]
-				ifNone: [ repositories anyOne ] ]
-		ifEmpty: [ nil ]
-]
+BaselineOfWelcomeBrowser >> repositoryLocation: spec [
 
-{ #category : 'private' }
-BaselineOfWelcomeBrowser >> repositoryLocation [
 	| locationFromIceberg |
-	
-	locationFromIceberg := (self class environment classNamed: #IceRepository)
-		ifNotNil: [ :iceberg |
-			iceberg registry 
-				detect: [ :each | each name = self repositoryName ]
-				ifNone: [ nil ] ].
-	
-	^ locationFromIceberg
-		ifNil: [ self packageRepository directory asFileReference parent ] 
+	locationFromIceberg := (self class environment classNamed:
+		                        #IceRepository) ifNotNil: [ :iceberg |
+		                       iceberg registry
+			                       detect: [ :each |
+			                       each name = self repositoryName ]
+			                       ifNone: [ nil ] ].
+
+	^ locationFromIceberg ifNil: [
+		  | tonelURL |
+		  tonelURL := self packageRepositoryURLForSpec: spec.
+		  (TonelRepository basicFromUrl: tonelURL) directory asFileReference
+			  parent ]
 ]
 
 { #category : 'private' }

--- a/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
+++ b/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
@@ -10,7 +10,7 @@ BaselineOfWelcomeBrowser >> baseline: spec [
 	<baseline>
 
 	spec for: #'common' do: [
-		spec postLoadDoIt: #loadThemeImages:.
+		spec postLoadDoIt: #loadThemeImagesWithTarget:spec:.
 		
 		self microdown: spec.
 		spec 
@@ -19,7 +19,7 @@ BaselineOfWelcomeBrowser >> baseline: spec [
 ]
 
 { #category : 'postload' }
-BaselineOfWelcomeBrowser >> loadThemeImages: spec [
+BaselineOfWelcomeBrowser >> loadThemeImagesWithTarget: aTarget spec: spec [
 	| themeClass location |
 
 	themeClass := self class environment classNamed: #StWelcomeTheme.


### PR DESCRIPTION
Redo #14 (Reverts revert in pharo-spec/NewTools-WelcomeBrowser#15).
Actually the issue was in the original PR.
This PR fixes the issue: the spec comes in the second argument of the postload directive and not the first one,