### PR TITLE
Cleanups, rework, improve and prepare for Pharo 12 release

### DIFF
--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -263,7 +263,7 @@ StWelcomeBrowser >> select: aTopic [
 		^ self ].
 
 	self flag: #HACK. "I need to select an interval to force the text to 
-	be at the begining, othewise it will show the last part"
+	be at the beginning, otherwise it will show the last part"
 	contentPanel 
 		documentFromString: aTopic value; 
 		selectionInterval: (1 to: 0)

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -95,7 +95,7 @@ Current Pharo development status:
 - [http://github.com/pharo-spec/NewTools-DocumentBrowser](http://github.com/pharo-spec/NewTools-DocumentBrowser)
 - [http://github.com/pharo-spec/Spec](http://github.com/pharo-spec/Spec)
 - [http://github.com/pharo-vcs/Iceberg](http://github.com/pharo-vcs/Iceberg)
-- [http://github.com/ObjectProfile/Roassal3](http://github.com/ObjectProfile/Roassal3)
+- [https://github.com/pharo-graphics/Roassal](https://github.com/pharo-graphics/Roassal)
 - [http://github.com/pillar-markup/Microdown](http://github.com/pillar-markup/Microdown)
 - [http://github.com/pillar-markup/BeautifulComments](http://github.com/pillar-markup/BeautifulComments)
 - [https://github.com/pharo-project/pharo-vm](https://github.com/pharo-project/pharo-vm)

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -251,7 +251,10 @@ Pharo has an excellent MOOC (Massive Open Online Course). You can find more info
 
 [http://mooc.pharo.org](http://mooc.pharo.org)
 
-Check the testimonies: they are great and fun. 
+Check the testimonies: they are great and fun. Additionally there is a new MOOC on 
+Advanced Object-Oriented Design and Development with Pharo
+
+[https://advanced-design-mooc.pharo.org](https://advanced-design-mooc.pharo.org)
 
 ### Books
 

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -161,7 +161,20 @@ A compendium of Pharo documentation can be found at:
 There you can find:
 - Pharo books: [http://books.pharo.org](http://books.pharo.org)
 - Screencasts: [https://www.youtube.com/channel/UCp3mNigANqkesFzdm058bvw](https://www.youtube.com/channel/UCp3mNigANqkesFzdm058bvw)
-- Presentations: [http://www.slideshare.net/pharoproject/](http://www.slideshare.net/pharoproject/)'
+- Presentations: [http://www.slideshare.net/pharoproject/](http://www.slideshare.net/pharoproject/)
+
+### Conferences
+Conferences are unique event where you can meet other Pharoers and Smalltalkers, discover latest advances, and share your experience.
+
+- [Pharo days](https://days.pharo.org)
+- [ESUG Website](https://esug.github.io)
+- [ESUG - Video channel](https://www.youtube.com/@esugboard)
+- [FAST Foundation](https://www.fast.org.ar)
+- [FAST - Video channel](https://www.youtube.com/@FASTFoundation)
+- [FAST - Smalltalks 2022](https://smalltalks2022.fast.org.ar/)
+- [FAST - Smalltalks 2023](https://smalltalks2023.fast.org.ar/)
+- [FAST - Smalltalks 2024](https://smalltalks2024.fast.org.ar/) (soon)
+'
 ]
 
 { #category : 'accessing - labels' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -103,7 +103,7 @@ Current Pharo development status:
 
 ## Changelog
 
-The complete list of changes can be viewed on a weekly basis [here](https://github.com/pharo-project/pharo-changelogs/tree/master/weekly).'
+The complete list of changes can be viewed on a weekly basis [here](https://github.com/pharo-project/pharo-changelogs).'
 ]
 
 { #category : 'accessing - labels' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -160,7 +160,7 @@ A compendium of Pharo documentation can be found at:
 
 There you can find:
 - Pharo books: [http://books.pharo.org](http://books.pharo.org)
-- Screencasts: [https://www.youtube.com/channel/UCp3mNigANqkesFzdm058bvw](https://www.youtube.com/channel/UCp3mNigANqkesFzdm058bvw)
+- Screencasts: [https://www.youtube.com/@Pharo-projectOrg](https://www.youtube.com/@Pharo-projectOrg)
 - Presentations: [http://www.slideshare.net/pharoproject/](http://www.slideshare.net/pharoproject/)
 
 ### Conferences

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -132,49 +132,7 @@ StWelcomeBrowser >> defaultLayout [
 { #category : 'accessing - contents' }
 StWelcomeBrowser >> helpContent [
 
-	^ '# Learn Pharo
-  
-### Getting help
-
-Pharo has a vibrant community that shares knowledge in different ways: 
-
-- The Pharo Users mailing list: [https://lists.pharo.org/list/pharo-users.lists.pharo.org](https://lists.pharo.org/list/pharo-users.lists.pharo.org)
-- The Pharo Discord server: [https://discord.gg/QewZMZa](https://discord.gg/QewZMZa)
-
-You can find more information, lists to browse/suscribe and places to share code at: 
-
-[http://pharo.org/community](http://pharo.org/community)
-
-### Using ProfStef
-You can learn Pharo by clicking on the following expression: 
-
-```pharoeval
-ProfStef go.
-```
-  
-### Follow the MOOC
-
-Pharo has an excellent MOOC (Massive Open Online Course). You can find more information here: 
-
-[http://mooc.pharo.org](http://mooc.pharo.org)
-
-Check the testimonies: they are great and fun. 
-
-### Books
-
-There are several free Pharo books that can be download here: 
-
-[http://books.pharo.org](http://books.pharo.org)
-
-A very interesting starting point would be looking into the "Updated Pharo by Example" free book. It is based on Pharo 90, but most .  
-You can find the book here:
-
-- [https://github.com/SquareBracketAssociates/UpdatedPharoByExample](https://github.com/SquareBracketAssociates/UpdatedPharoByExample)
-- [https://github.com/SquareBracketAssociates/PharoByExample9](https://github.com/SquareBracketAssociates/PharoByExample9)
-or order your copy here:
-- [Pharo 9 by example on Amazon](https://www.amazon.com/Pharo-example-Technology-Collection/dp/2322394106/)
-
-### Help
+	^ '### Help
 
 A compendium of Pharo documentation can be found at: 
 
@@ -220,6 +178,31 @@ StWelcomeBrowser >> initializeWindow: aWindowPresenter [
 		centered
 ]
 
+{ #category : 'accessing - contents' }
+StWelcomeBrowser >> learnContent [
+
+	^ '# Learn Pharo
+  
+### Getting help
+
+Pharo has a vibrant community that shares knowledge in different ways: 
+
+- The Pharo Users mailing list: [https://lists.pharo.org/list/pharo-users.lists.pharo.org](https://lists.pharo.org/list/pharo-users.lists.pharo.org)
+- The Pharo Discord server: [https://discord.gg/QewZMZa](https://discord.gg/QewZMZa)
+
+You can find more information, lists to browse/suscribe and places to share code at: 
+
+[http://pharo.org/community](http://pharo.org/community)
+
+### Using ProfStef
+You can learn Pharo by clicking on the following expression: 
+
+```pharoeval
+ProfStef go.
+```
+'
+]
+
 { #category : 'private' }
 StWelcomeBrowser >> newContainerTopic [ 
 
@@ -256,6 +239,32 @@ StWelcomeBrowser >> newTopicTitle: aTitle presenterClass: aClass [
 		title: aTitle;
 		contentPresenter: aClass new;
 		yourself
+]
+
+{ #category : 'accessing - contents' }
+StWelcomeBrowser >> resourceContent [
+
+	^ '### Follow the MOOC
+
+Pharo has an excellent MOOC (Massive Open Online Course). You can find more information here: 
+
+[http://mooc.pharo.org](http://mooc.pharo.org)
+
+Check the testimonies: they are great and fun. 
+
+### Books
+
+There are several free Pharo books that can be download here: 
+
+[http://books.pharo.org](http://books.pharo.org)
+
+A very interesting starting point would be looking into the "Updated Pharo by Example" free book. It is based on Pharo 90, but most .  
+You can find the book here:
+
+- [https://github.com/SquareBracketAssociates/UpdatedPharoByExample](https://github.com/SquareBracketAssociates/UpdatedPharoByExample)
+- [https://github.com/SquareBracketAssociates/PharoByExample9](https://github.com/SquareBracketAssociates/PharoByExample9)
+or order your copy here:
+- [Pharo 9 by example on Amazon](https://www.amazon.com/Pharo-example-Technology-Collection/dp/2322394106/)'
 ]
 
 { #category : 'private' }
@@ -307,6 +316,8 @@ StWelcomeBrowser >> topics [
 	self newTopicTitle: self welcomeLabel contents: self welcomeContent.
 	self newTopicTitle: self helpLabel presenterClass: StWelcomeSetupPresenter.
 	"self newTopicTitle: self setupLabel contents: self setupContent."
+	self newTopicTitle: self helpLabel contents: self learnContent.
+	self newTopicTitle: self helpLabel contents: self resourceContent.  	
 	self newTopicTitle: self helpLabel contents: self helpContent. 
 	self newTopicTitle: self changesLabel contents: self changesContent. 
 	}

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -10,8 +10,9 @@ Class {
 		'millerList',
 		'paginator'
 	],
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Base',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Base'
 }
 
 { #category : 'accessing' }
@@ -139,11 +140,6 @@ The complete list of changes can be viewed on a weekly basis [here](https://gith
 StWelcomeBrowser >> changesLabel [
 
 	^ 'Changes in Pharo ', self version
-]
-
-{ #category : 'initialization' }
-StWelcomeBrowser >> connectPresenters [
-
 ]
 
 { #category : 'layout' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -101,11 +101,6 @@ Current Pharo development status:
 - [http://github.com/pillar-markup/BeautifulComments](http://github.com/pillar-markup/BeautifulComments)
 - [https://github.com/pharo-project/pharo-vm](https://github.com/pharo-project/pharo-vm)
 
-## Contributors
-We always say Pharo is yours. It is yours because we made it for you, but most importantly, because it is made by the invaluable contributions of our great community (yourself).  
-A large community of people from all around the world contributed to Pharo 12.0 by making pull requests, reporting bugs, participating in discussion threads, providing feedback and more.  
-Thank you all for your contributions!  
-
 ## Changelog
 
 The complete list of changes can be viewed on a weekly basis [here](https://github.com/pharo-project/pharo-changelogs/tree/master/weekly).'
@@ -115,6 +110,32 @@ The complete list of changes can be viewed on a weekly basis [here](https://gith
 StWelcomeBrowser >> changesLabel [
 
 	^ 'Changes in Pharo ', self version
+]
+
+{ #category : 'accessing - contents' }
+StWelcomeBrowser >> contributorContent [
+
+	^ '## Contributors
+We always say Pharo is yours. It is yours because we made it for you, but most importantly, because it is made by the invaluable contributions of our great community (yourself).  
+
+A large community of people from all around the world contributed to Pharo 12.0 by making pull requests, reporting bugs, participating in discussion threads, providing feedback and more. If you want to join us and contribute as well please check
+
+- [https://pharo.org/contribute](https://pharo.org/contribute) 
+
+Thank you all for your contributions!  
+
+## Pharo Association
+
+The Pharo association''s goal is to let individuals support the promotion and development of Pharo. If you want to support and join visit
+
+- [https://association.pharo.org](https://association.pharo.org)
+
+## Pharo Consortium
+
+As a company or organization you might want to become a consortium member you help promote Pharo. The consortium promotes Pharo by supporting conferences, books, videos, exhibitions, and conference participation.
+
+- [https://consortium.pharo.org](https://consortium.pharo.org)
+'
 ]
 
 { #category : 'layout' }
@@ -323,7 +344,8 @@ StWelcomeBrowser >> topics [
 	self newTopicTitle: self helpLabel contents: self learnContent.
 	self newTopicTitle: self helpLabel contents: self resourceContent.  	
 	self newTopicTitle: self helpLabel contents: self helpContent. 
-	self newTopicTitle: self changesLabel contents: self changesContent. 
+	self newTopicTitle: self changesLabel contents: self changesContent.
+	self newTopicTitle: self helpLabel contents: self contributorContent.  
 	}
 ]
 

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -118,15 +118,13 @@ StWelcomeBrowser >> contributorContent [
 	^ '## Contributors
 We always say Pharo is yours. It is yours because we made it for you, but most importantly, because it is made by the invaluable contributions of our great community (yourself).  
 
-A large community of people from all around the world contributed to Pharo 12.0 by making pull requests, reporting bugs, participating in discussion threads, providing feedback and more. If you want to join us and contribute as well please check
-
-- [https://pharo.org/contribute](https://pharo.org/contribute) 
+A large community of people from all around the world contributed to Pharo 12.0 by making pull requests, reporting bugs, participating in discussion threads, providing feedback and more. If you want to join us and contribute as well please check [https://pharo.org/contribute](https://pharo.org/contribute) 
 
 Thank you all for your contributions!  
 
 ## Pharo Association
 
-The Pharo association''s goal is to let individuals support the promotion and development of Pharo. If you want to support and join visit
+The Pharo association''s goal is to let individuals support the promotion and development of Pharo. If you want to support us and join then visit
 
 - [https://association.pharo.org](https://association.pharo.org)
 
@@ -273,7 +271,7 @@ Pharo has an excellent MOOC (Massive Open Online Course). You can find more info
 [http://mooc.pharo.org](http://mooc.pharo.org)
 
 Check the testimonies: they are great and fun. Additionally there is a new MOOC on 
-Advanced Object-Oriented Design and Development with Pharo
+"Advanced Object-Oriented Design and Development with Pharo" available
 
 [https://advanced-design-mooc.pharo.org](https://advanced-design-mooc.pharo.org)
 
@@ -283,13 +281,12 @@ There are several free Pharo books that can be download here:
 
 [http://books.pharo.org](http://books.pharo.org)
 
-A very interesting starting point would be looking into the "Updated Pharo by Example" free book. It is based on Pharo 90, but most .  
-You can find the book here:
+A very interesting starting point would be looking into the "Updated Pharo by Example" free book. It is based on Pharo 90, so using this version is recommended to learn.
 
-- [https://github.com/SquareBracketAssociates/UpdatedPharoByExample](https://github.com/SquareBracketAssociates/UpdatedPharoByExample)
-- [https://github.com/SquareBracketAssociates/PharoByExample9](https://github.com/SquareBracketAssociates/PharoByExample9)
-or order your copy here:
-- [Pharo 9 by example on Amazon](https://www.amazon.com/Pharo-example-Technology-Collection/dp/2322394106/)'
+You can find the book here: [https://github.com/SquareBracketAssociates/PharoByExample9](https://github.com/SquareBracketAssociates/PharoByExample9)
+and you can order a copy here: [Pharo 9 by example on Amazon](https://www.amazon.com/Pharo-example-Technology-Collection/dp/2322394106/)
+
+Many of the Pharo books and bookolets are available in [https://github.com/SquareBracketAssociates](https://github.com/SquareBracketAssociates) and you can contribute to them.'
 ]
 
 { #category : 'private' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -166,11 +166,14 @@ There are several free Pharo books that can be download here:
 
 [http://books.pharo.org](http://books.pharo.org)
 
-A very interesting starting point would be looking into the "Updated Pharo by Example" free book. It is still a work in progress for Pharo 90, but most of it is already done.  
+A very interesting starting point would be looking into the "Updated Pharo by Example" free book. It is based on Pharo 90, but most .  
 You can find the book here:
 
 - [https://github.com/SquareBracketAssociates/UpdatedPharoByExample](https://github.com/SquareBracketAssociates/UpdatedPharoByExample)
-- [https://github.com/SquareBracketAssociates/PharoByExample80](https://github.com/SquareBracketAssociates/PharoByExample80)
+- [https://github.com/SquareBracketAssociates/PharoByExample9](https://github.com/SquareBracketAssociates/PharoByExample9)
+or order your copy here:
+- [Pharo 9 by example on Amazon](https://www.amazon.com/Pharo-example-Technology-Collection/dp/2322394106/)
+
 ### Help
 
 A compendium of Pharo documentation can be found at: 

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -93,6 +93,7 @@ Current Pharo development status:
 3. xxxx Pull requests processed since Pharo 11, not counting separately managed projects:
 - [http://github.com/pharo-spec/NewTools](http://github.com/pharo-spec/NewTools)
 - [http://github.com/pharo-spec/NewTools-DocumentBrowser](http://github.com/pharo-spec/NewTools-DocumentBrowser)
+- [https://github.com/pharo-spec/NewTools-WelcomeBrowser](https://github.com/pharo-spec/NewTools-WelcomeBrowser)
 - [http://github.com/pharo-spec/Spec](http://github.com/pharo-spec/Spec)
 - [http://github.com/pharo-vcs/Iceberg](http://github.com/pharo-vcs/Iceberg)
 - [https://github.com/pharo-graphics/Roassal](https://github.com/pharo-graphics/Roassal)

--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -71,52 +71,26 @@ StWelcomeBrowser >> addPresenter: aPresenter [
 { #category : 'accessing - contents' }
 StWelcomeBrowser >> changesContent [
 
-	^ '# Pharo 11 changes overview
+	^ '# Pharo 12 changes overview
 
 A large international community of developers worked hard to prepare a new release of the Pharo platform.
 
 ## Highlights
 
 ### Tools
-- Iceberg (the Git client/VCS control tool) has received a lot of tweaks and fixes to work better with GitHub and other remote control files.
-- The debugger now incorporates a lot of tweaks and, notably, the capability of adding bindings in the context interaction model.
-- TimeProfiler (the profiling tool) has a new UI and also incorporates the alternative Andreas Profiler.
-- DrTests (the Test Runner alternative) has been improved and updated to the latest Spec.
-- There is a new implementation of Rewrite tools. 
-- There is a new tool: The Document Browser, which allows the visualization of Microdown (Markdown compatible) documents placed on the web or locally. 
-- Calypso (the System Browser) has incorporated some interesting mini tools: package dependency and baseline visualization.
-- We have introduced new and improved Inspectors, notably for AST/Blocks/IR, among others.
-- All versions of NewTools, Spec, Roassal and Microdown have been updated with a lot of bug fixes. 
+- ... 
 
 ### System 
-- Slots now have a Setting for unrestricted definitions.
-- Slots now allow more complex Slot definitions (cascade).
-- Compiler support for full blocks without outer context.
-- We have enabled optionInlineTimesRepeat and optionInlineRepeat by default.
-- Adding an API in OCBytecodeToASTCache, RBMethodNode and RBBlockNode to map AST nodes to a PC range.
-- Add a "parse plugin" mechanism to OpalCompiler.
-- Improve faulty parsing.
-- A Lots of bug fixes and cleanups.
-- Constant Block Closures are created at compile time (speeds up both creating and evaluation of [#blockslikethis])
-- Support for ephemerons.
+- ...
    
 ### Virtual machine
-- Ephemerons are production ready (a large number of Ephemerons supported, leaks fixed, support for old finalization, tests).
-- Improving the Memory Map of the VM (using constant positions).
-- Initial support for Single-Instruction Multiple-Data (SIMD)
-    - Initialization of new objects using SIMD (ARM64)
-    - Adding Bytecode Extensions to support SIMD instructions
-    - Adding Vector Registers
-    - Vector Register bytecodes
-- Third-Party Dependency Update (newer versions, graphic libraries using hardware acceleration).
-- Fixing errors and simplification of primitives.
-- Clean Ups: We have removed a significant amount of old code, notably old experiments, dead code, and unused code such as Newspeak and unused plugins.
+- ...
 
 ## Status
 Current Pharo development status:
-1. 309 forks on GitHub
-2. 972 issues closed since Pharo 10
-3. 1412 Pull requests processed since Pharo 10, not counting separately managed projects:
+1. xxx forks on GitHub
+2. xxx issues closed since Pharo 11
+3. xxxx Pull requests processed since Pharo 11, not counting separately managed projects:
 - [http://github.com/pharo-spec/NewTools](http://github.com/pharo-spec/NewTools)
 - [http://github.com/pharo-spec/NewTools-DocumentBrowser](http://github.com/pharo-spec/NewTools-DocumentBrowser)
 - [http://github.com/pharo-spec/Spec](http://github.com/pharo-spec/Spec)
@@ -124,11 +98,11 @@ Current Pharo development status:
 - [http://github.com/ObjectProfile/Roassal3](http://github.com/ObjectProfile/Roassal3)
 - [http://github.com/pillar-markup/Microdown](http://github.com/pillar-markup/Microdown)
 - [http://github.com/pillar-markup/BeautifulComments](http://github.com/pillar-markup/BeautifulComments)
-- [http://github.com/pharo-project/opensmalltalk-vm](http://github.com/pharo-project/opensmalltalk-vm)
+- [https://github.com/pharo-project/pharo-vm](https://github.com/pharo-project/pharo-vm)
 
 ## Contributors
 We always say Pharo is yours. It is yours because we made it for you, but most importantly, because it is made by the invaluable contributions of our great community (yourself).  
-A large community of people from all around the world contributed to Pharo 11.0 by making pull requests, reporting bugs, participating in discussion threads, providing feedback and more.  
+A large community of people from all around the world contributed to Pharo 12.0 by making pull requests, reporting bugs, participating in discussion threads, providing feedback and more.  
 Thank you all for your contributions!  
 
 ## Changelog

--- a/src/NewTools-WelcomeBrowser/StWelcomeDarkTheme.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeDarkTheme.class.st
@@ -4,8 +4,9 @@ Define the dark theme
 Class {
 	#name : 'StWelcomeDarkTheme',
 	#superclass : 'StWelcomeTheme',
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Themes',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Themes'
 }
 
 { #category : 'private' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeLightTheme.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeLightTheme.class.st
@@ -4,8 +4,9 @@ Define the light theme.
 Class {
 	#name : 'StWelcomeLightTheme',
 	#superclass : 'StWelcomeTheme',
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Themes',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Themes'
 }
 
 { #category : 'private' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeSetupPresenter.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeSetupPresenter.class.st
@@ -11,8 +11,9 @@ Class {
 		'settingsHelpLabel',
 		'settingsButton'
 	],
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Presenters',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Presenters'
 }
 
 { #category : 'layout' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeStyleContributor.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeStyleContributor.class.st
@@ -4,8 +4,9 @@ A style contributor with welcome browser specifics
 Class {
 	#name : 'StWelcomeStyleContributor',
 	#superclass : 'StPharoStyleContributor',
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Styles',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Styles'
 }
 
 { #category : 'styles' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeTheme.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeTheme.class.st
@@ -10,8 +10,9 @@ Class {
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Themes',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Themes'
 }
 
 { #category : 'accessing' }
@@ -47,7 +48,7 @@ StWelcomeTheme class >> uniqueInstance [
 	^ uniqueInstance ifNil: [ uniqueInstance := self basicNew initialize ]
 ]
 
-{ #category : 'accessing' }
+{ #category : 'activation' }
 StWelcomeTheme >> activate [
 
 	self themeClass beCurrent

--- a/src/NewTools-WelcomeBrowser/StWelcomeTheme.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeTheme.class.st
@@ -69,7 +69,7 @@ StWelcomeTheme >> imageFileName [
 { #category : 'testing' }
 StWelcomeTheme >> isActive [
 
-	^ UITheme current class = self themeClass
+	^ Smalltalk ui theme class = self themeClass
 ]
 
 { #category : 'accessing' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeTopicContainerPresenter.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeTopicContainerPresenter.class.st
@@ -4,8 +4,9 @@ A topic that will contain subtopics (for example `StWelcomeSetupPresenter`)
 Class {
 	#name : 'StWelcomeTopicContainerPresenter',
 	#superclass : 'StWelcomeTopicPresenter',
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Presenters',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Presenters'
 }
 
 { #category : 'accessing' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeTopicMicrodownPresenter.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeTopicMicrodownPresenter.class.st
@@ -4,8 +4,9 @@ A topic that will include microdown text.
 Class {
 	#name : 'StWelcomeTopicMicrodownPresenter',
 	#superclass : 'StWelcomeTopicPresenter',
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Presenters',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Presenters'
 }
 
 { #category : 'accessing' }

--- a/src/NewTools-WelcomeBrowser/StWelcomeTopicPresenter.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeTopicPresenter.class.st
@@ -15,8 +15,9 @@ Class {
 		'nextBlock',
 		'previousBlock'
 	],
-	#category : 'NewTools-WelcomeBrowser',
-	#package : 'NewTools-WelcomeBrowser'
+	#category : 'NewTools-WelcomeBrowser-Presenters',
+	#package : 'NewTools-WelcomeBrowser',
+	#tag : 'Presenters'
 }
 
 { #category : 'private - actions' }


### PR DESCRIPTION
- mention Pharo 12 instead of 11
- Added many cleanups 
- add conferences
- add consortium and association
- fix broken link
- Pharo90 book update to fix #2 
- Fix typos
- do not use "UITheme current" anymore
- fix lints
- ...
See each commit description for each change