### PR TITLE
Add non-case sensitive comparison to iceberg repository lookup

### DIFF
--- a/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
+++ b/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
@@ -39,19 +39,22 @@ BaselineOfWelcomeBrowser >> microdown: spec [
 { #category : 'private' }
 BaselineOfWelcomeBrowser >> repositoryLocation: spec [
 
-	| locationFromIceberg |
-	locationFromIceberg := (self class environment classNamed:
-		                        #IceRepository) ifNotNil: [ :iceberg |
-		                       iceberg registry
-			                       detect: [ :each |
-			                       each name = self repositoryName ]
-			                       ifNone: [ nil ] ].
+	| icebergRepository |
+	icebergRepository := (self class environment classNamed:
+		                      #IceRepository) ifNotNil: [ :iceberg |
+		                     iceberg registry
+			                     detect: [ :each |
+			                     each name asLowercase
+			                     = self repositoryName asLowercase ]
+			                     ifNone: [ nil ] ].
 
-	^ locationFromIceberg ifNil: [
-		  | tonelURL |
-		  tonelURL := self packageRepositoryURLForSpec: spec.
-		  (TonelRepository basicFromUrl: tonelURL) directory asFileReference
-			  parent ]
+	^ icebergRepository
+		  ifNil: [
+			  | tonelURL |
+			  tonelURL := self packageRepositoryURLForSpec: spec.
+			  (TonelRepository basicFromUrl: tonelURL) directory
+				  asFileReference parent ]
+		  ifNotNil: [ icebergRepository location ]
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
I reproduced https://github.com/pharo-project/pharo/issues/15904 locally.
There is (at least) an iceberg registry with a casing problem, so the comparison fails and tries to lookup a tonel repository from a seemingly non-tonel url (external projects are loaded using a `github://` url).