### PR TITLE
Change #logo for StWelcomeBrowser to answer an ImageMorph with the FormSet for the icon

### DIFF
--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -18,7 +18,7 @@ Class {
 { #category : 'accessing' }
 StWelcomeBrowser class >> logo [
 
-	^ self iconNamed: #pharoBig
+	^ ImageMorph withFormSet: (self iconFormSetNamed: #pharoBig)
 ]
 
 { #category : 'world menu' }


### PR DESCRIPTION
This pull request changes #logo for StWelcomeBrowser to answer an ImageMorph with the FormSet for the icon.

This requires [pharo-icon-packs pull request #11](https://github.com/pharo-project/pharo-icon-packs/pull/11) to be merged first.