### PR TITLE
Change #menuCommandOn: for StWelcomeBrowser to use the icon #smallPharo

### DIFF
--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -29,7 +29,7 @@ StWelcomeBrowser class >> menuCommandOn: aBuilder [
 		parent: #PharoHelp;
 		order: 1;
 		action: [ self open ];
-		icon: ((self iconNamed: #pharo) scaledToSize: (16@16) scaledByDisplayScaleFactor);
+		iconName: #smallPharo;
 		help: 'Welcome window for Pharo'
 ]
 


### PR DESCRIPTION
This pull request changes #menuCommandOn: for StWelcomeBrowser to use the icon #smallPharo instead of scaling the icon #pharo.

This requires merging [pharo-icon-packs pull request #12](https://github.com/pharo-project/pharo-icon-packs/pull/12) first. Once that’s merged, [Pharo pull request #16496](https://github.com/pharo-project/pharo/pull/16496) can be merged as well.