### PR TITLE
Remove senders of scaledByDisplayScaleFactor and displayScaleFactor

### DIFF
--- a/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
+++ b/src/NewTools-WelcomeBrowser/StWelcomeBrowser.class.st
@@ -58,7 +58,7 @@ StWelcomeBrowser class >> openForRelease [
 { #category : 'accessing' }
 StWelcomeBrowser class >> windowExtent [
 
-	^ (720@550) scaledByDisplayScaleFactor
+	^ (720@550)
 ]
 
 { #category : 'private' }


### PR DESCRIPTION
Remove senders of scaledByDisplayScaleFactor and displayScaleFactor.
This was superseeded by new scale factor support integrated since Pharo12