### PR TITLE
Make BaselineOfWelcomeBrowser for Pharo 11 use the tag ‘v2.4.1’ instead of the branch ‘integration’ for Microdown

### DIFF
--- a/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
+++ b/src/BaselineOfWelcomeBrowser/BaselineOfWelcomeBrowser.class.st
@@ -31,7 +31,7 @@ BaselineOfWelcomeBrowser >> microdown: spec [
 
 	spec baseline: 'Microdown' with: [
 		spec
-			repository: 'github://pillar-markup/Microdown:integration/src';
+			repository: 'github://pillar-markup/Microdown:v2.4.1/src';
 			loads: #('RichText') ]
 ]
 


### PR DESCRIPTION
This pull request makes BaselineOfWelcomeBrowser for Pharo 11 use the tag ‘v2.4.1’ instead of the branch ‘integration’ for Microdown, see [Pharo issue #17391](https://github.com/pharo-project/pharo/issues/17391).